### PR TITLE
refactor: 라우트 마운트를 /api/<도메인> 네임스페이스로 통일

### DIFF
--- a/src/components/Campsite/ReviewCard.jsx
+++ b/src/components/Campsite/ReviewCard.jsx
@@ -7,7 +7,7 @@ const ReviewCard = ({ item, userName }) => {
   const { _id, author, review, createdAt, score, contentId } = item;
   const [modalOpen, setModalOpen] = useState(false);
   const handleReviewDelete = async () => {
-    await fetch(`${process.env.REACT_APP_SERVER_URL}/review/${_id}`, {
+    await fetch(`${process.env.REACT_APP_SERVER_URL}/api/campsites/review/${_id}`, {
       method: "DELETE",
       credentials: "include",
     });

--- a/src/components/Campsite/ReviewCreateModal.jsx
+++ b/src/components/Campsite/ReviewCreateModal.jsx
@@ -25,7 +25,7 @@ const ReviewCreateModal = ({ setModalOpen, id }) => {
       return;
     }
     try {
-      const response = await fetch(`${url}/review/${userObjId}`, {
+      const response = await fetch(`${url}/api/campsites/review/${userObjId}`, {
         method: "POST",
         body: JSON.stringify({
           score,

--- a/src/components/Campsite/ReviewEditModal.jsx
+++ b/src/components/Campsite/ReviewEditModal.jsx
@@ -25,7 +25,7 @@ const ReviewEditModal = ({ setModalOpen, item }) => {
       return;
     }
     try {
-      const response = await fetch(`${url}/review/${_id}`, {
+      const response = await fetch(`${url}/api/campsites/review/${_id}`, {
         method: "PUT",
         body: JSON.stringify({
           score: editScore,

--- a/src/components/HeaderFooter/Header.jsx
+++ b/src/components/HeaderFooter/Header.jsx
@@ -16,7 +16,7 @@ const Header = () => {
   const [gnbOn, setGnbOn] = useState(false);
   useEffect(() => {
     const fetchProfile = async () => {
-      const response = await fetch(`${url}/profile`, {
+      const response = await fetch(`${url}/api/auth/profile`, {
         credentials: "include",
       });
       if (response.ok) {
@@ -28,7 +28,7 @@ const Header = () => {
   }, [dispatch, location.pathname]);
   const handleLogout = (e) => {
     e.preventDefault();
-    fetch(`${url}/logout`, {
+    fetch(`${url}/api/auth/logout`, {
       method: "POST",
       credentials: "include",
     });

--- a/src/components/MyPage/CouponCard.jsx
+++ b/src/components/MyPage/CouponCard.jsx
@@ -41,7 +41,7 @@ const CouponCard = ({ coupon, updateCoupons }) => {
 
   const handleCouponDel = async () => {
     try {
-      const response = await fetch(`${url}/coupon/${coupon._id}`, {
+      const response = await fetch(`${url}/api/my-page/coupon/${coupon._id}`, {
         method: "DELETE",
         credentials: "include",
       });
@@ -56,7 +56,7 @@ const CouponCard = ({ coupon, updateCoupons }) => {
 
   const handleCouponUsed = async () => {
     try {
-      const response = await fetch(`${url}/coupon/${coupon._id}`, {
+      const response = await fetch(`${url}/api/my-page/coupon/${coupon._id}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/pages/Campsite/SiteDetail.jsx
+++ b/src/pages/Campsite/SiteDetail.jsx
@@ -117,7 +117,7 @@ const SiteDetail = () => {
     const getReviewLst = async () => {
       try {
         console.log("리뷰 가져오기 실행");
-        const response = await fetch(`${url}/review/${id}`, {
+        const response = await fetch(`${url}/api/campsites/review/${id}`, {
           method: "GET",
         });
         const data = await response.json();

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -31,7 +31,7 @@ const LoginPage = () => {
       const loginDate = new Date().toISOString();
       console.log(loginDate);
 
-      const response = await fetch(`${url}/login`, {
+      const response = await fetch(`${url}/api/auth/login`, {
         method: "POST",
         body: JSON.stringify({ username, password, loginDate }),
         headers: { "Content-Type": "application/json" },
@@ -60,7 +60,7 @@ const LoginPage = () => {
 
   const logout = async () => {
     try {
-      const response = await fetch(`${url}/logout`, {
+      const response = await fetch(`${url}/api/auth/logout`, {
         method: "POST",
         credentials: "include",
       });
@@ -121,7 +121,7 @@ const LoginPage = () => {
       <span className={style.divider}>
         <span className={style.innerText}>또는</span>
       </span>
-      <a href={`${process.env.REACT_APP_SERVER_URL}` + "/authorize"}>
+      <a href={`${process.env.REACT_APP_SERVER_URL}` + "/api/auth/authorize"}>
         <img
           src="//k.kakaocdn.net/14/dn/btqCn0WEmI3/nijroPfbpCa4at5EIsjyf0/o.jpg"
           width="222"

--- a/src/pages/MyPage/Bingo.jsx
+++ b/src/pages/MyPage/Bingo.jsx
@@ -22,7 +22,7 @@ const Bingo = () => {
   console.log("objId", userObjId);
   const updateMission = async () => {
     try {
-      const response = await fetch(`${url}/update-mission/${userObjId}`, {
+      const response = await fetch(`${url}/api/my-page/update-mission/${userObjId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
@@ -46,7 +46,7 @@ const Bingo = () => {
   };
   const getBingoPattern = async () => {
     try {
-      const response = await fetch(`${url}/bingo-pattern/${userObjId}`, {
+      const response = await fetch(`${url}/api/my-page/bingo-pattern/${userObjId}`, {
         method: "GET",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
@@ -59,7 +59,7 @@ const Bingo = () => {
   };
   const getBingoArea = async () => {
     try {
-      const response = await fetch(`${url}/bingo-area/${userObjId}`, {
+      const response = await fetch(`${url}/api/my-page/bingo-area/${userObjId}`, {
         method: "GET",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
@@ -72,7 +72,7 @@ const Bingo = () => {
   };
   const getBingoCount = async () => {
     try {
-      const response = await fetch(`${url}/bingo-count/${userObjId}`, {
+      const response = await fetch(`${url}/api/my-page/bingo-count/${userObjId}`, {
         method: "GET",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
@@ -85,7 +85,7 @@ const Bingo = () => {
   };
   const resetBingo = async () => {
     try {
-      const response = await fetch(`${url}/reset-bingo/${userObjId}`, {
+      const response = await fetch(`${url}/api/my-page/reset-bingo/${userObjId}`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
@@ -100,7 +100,7 @@ const Bingo = () => {
   const couponDuplicateCheck = async (coupon) => {
     try {
       const newCoupon = coupon;
-      const response = await fetch(`${url}/check-duplicate/${userObjId}`, {
+      const response = await fetch(`${url}/api/my-page/check-duplicate/${userObjId}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -124,7 +124,7 @@ const Bingo = () => {
   const couponIssuance = async (coupon) => {
     try {
       const newCoupon = coupon;
-      const response = await fetch(`${url}/coupon/${userObjId}`, {
+      const response = await fetch(`${url}/api/my-page/coupon/${userObjId}`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/pages/MyPage/Coupon.jsx
+++ b/src/pages/MyPage/Coupon.jsx
@@ -12,7 +12,7 @@ const Coupon = () => {
   useEffect(() => {
     const getCoupon = async () => {
       try {
-        const response = await fetch(`${url}/coupon/${userObjId}`, {
+        const response = await fetch(`${url}/api/my-page/coupon/${userObjId}`, {
           method: "GET",
           headers: { Accept: "application/json" },
           credentials: "include",

--- a/src/pages/MyPage/CustomerService.jsx
+++ b/src/pages/MyPage/CustomerService.jsx
@@ -44,7 +44,7 @@ const CustomerService = () => {
     } else {
       setContentErrMsg("");
     }
-    const response = await fetch(`${url}/inquiry`, {
+    const response = await fetch(`${url}/api/my-page/inquiry`, {
       method: "POST",
       body: JSON.stringify({
         title,
@@ -61,7 +61,7 @@ const CustomerService = () => {
   };
   const deleteUser = async () => {
     try {
-      const response = await fetch(`${url}/user/${userObjId}`, {
+      const response = await fetch(`${url}/api/my-page/user/${userObjId}`, {
         method: "DELETE",
         headers: { "Content-type": "application/json" },
         credentials: "include",

--- a/src/pages/MyPage/EditInfo.jsx
+++ b/src/pages/MyPage/EditInfo.jsx
@@ -35,7 +35,7 @@ const EditInfo = () => {
       setError("nickname", AUTH_ERROR.BLANK.NICKNAME);
       return;
     }
-    const response = await fetch(`${url}/duplicate-check`, {
+    const response = await fetch(`${url}/api/my-page/duplicate-check`, {
       method: "POST",
       body: JSON.stringify({ nickname }),
       headers: {
@@ -52,7 +52,7 @@ const EditInfo = () => {
     }
   };
   const passwordCheck = async (password) => {
-    const response = await fetch(`${url}/password-check/${userObjId}`, {
+    const response = await fetch(`${url}/api/my-page/password-check/${userObjId}`, {
       method: "POST",
       body: JSON.stringify({ password }),
       headers: {
@@ -91,14 +91,14 @@ const EditInfo = () => {
       setErrorMsg({ nickname: "", currentPW: "", newPW: "", checkPW: "" });
     }
     const handleLogout = () => {
-      fetch(`${url}/logout`, {
+      fetch(`${url}/api/auth/logout`, {
         method: "POST",
         credentials: "include",
       });
       dispatch(setUserAllInfo(null));
       navigate("/");
     };
-    const response = await fetch(`${url}/user/${userObjId}`, {
+    const response = await fetch(`${url}/api/my-page/user/${userObjId}`, {
       method: "PUT",
       body: JSON.stringify({ nickname, password: newPW }),
       headers: { "Content-Type": "application/json" },

--- a/src/pages/MyPage/MyPost.jsx
+++ b/src/pages/MyPage/MyPost.jsx
@@ -10,7 +10,7 @@ const MyPost = () => {
   useEffect(() => {
     const getMyPostList = async () => {
       try {
-        const response = await fetch(`${url}/post/${userObjId}`, {
+        const response = await fetch(`${url}/api/my-page/post/${userObjId}`, {
           method: "GET",
           headers: { Accept: "application/json" },
           credentials: "include",

--- a/src/pages/MyPage/Sale.jsx
+++ b/src/pages/MyPage/Sale.jsx
@@ -11,7 +11,7 @@ const Sale = () => {
 
   const getSalePostList = async () => {
     try {
-      const response = await fetch(`${url}/sale-post/${userId}`, {
+      const response = await fetch(`${url}/api/my-page/sale-post/${userId}`, {
         method: "GET",
         headers: { Accept: "application/json" },
         credentials: "include",

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -35,7 +35,7 @@ const RegisterPage = () => {
 
     //백엔드로 post 요청 및 응답
     try {
-      const response = await fetch(`${url}/register`, {
+      const response = await fetch(`${url}/api/auth/register`, {
         method: "POST",
         body: JSON.stringify({
           username,
@@ -107,7 +107,7 @@ const RegisterPage = () => {
       <span className={style.divider}>
         <span className={style.innerText}>또는</span>
       </span>
-      <a href={`${process.env.REACT_APP_SERVER_URL}` + "/authorize"}>
+      <a href={`${process.env.REACT_APP_SERVER_URL}` + "/api/auth/authorize"}>
         <img
           src="//k.kakaocdn.net/14/dn/btqCn0WEmI3/nijroPfbpCa4at5EIsjyf0/o.jpg"
           width="222"


### PR DESCRIPTION
14개 파일의 fetch 호출 경로를 /api/auth, /api/my-page, /api/campsites 기준으로 변경